### PR TITLE
Resolved the CSS file path conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- displays site properly based on user's device -->
-  <link rel="stylesheet" media="screen and (max-width:1440px)" href="../css/desktop.css">
-  <link rel="stylesheet" media="screen and (min-width:375px) and (max-width:450px)" href="../css/mobile.css">
+  <!-- <link rel="stylesheet" type="text/css" media="screen and (max-width:1440px)" href="css/desktop.css"> -->
+  <link rel="stylesheet" type="text/css" href="css/desktop.css">
+  <link rel="stylesheet" type="text/css" media="screen and (min-width:374px) and (max-width:450px)" href="css/mobile.css">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png">
   <link href="https://fonts.googleapis.com/css?family=Karla" rel="stylesheet">
   <title>Frontend Mentor | Single Price Grid Component</title>


### PR DESCRIPTION
I went through the code and found some bugs that I resolved.

- It's not necessary to define a media queryfor desktop design. For instance
`<link rel="stylesheet" type="text/css" media="screen and (max-width:1440px)" href="css/desktop.css">`
failed on my PC because my screen width was more than the defined 1440px. 

- The correct path for the CSS file would be `css/desktop.css` and not `./css/desktop.css` because **_the index.html_** and the css folder are in the same directory.

Finally I was able to resolve this issue and the design is visible now:
![Screenshot 2021-05-04 081246](https://user-images.githubusercontent.com/74287708/116955826-4282f680-acb1-11eb-9e7c-c358ed8b0a01.png)

![_C__Users_Raj%20Aryan_Desktop_Repos_single-price-component_single-price-grid-component_index html(iPhone X)](https://user-images.githubusercontent.com/74287708/116955882-5fb7c500-acb1-11eb-86be-333f04774cab.png)
